### PR TITLE
Use a relative publicPath (Fixes #6)

### DIFF
--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -77,7 +77,7 @@ function configureWebpack(env) {
 
     const srcPath = path.resolve(basePath, 'src'),
         outPath = path.resolve(basePath, 'build'),
-        publicPath = '/';  // Path on which fully built app is served - i.e. root context
+        publicPath = prodBuild ? '../' : '/';  // Path on which fully built app is served - i.e. root context
 
     // Resolve Hoist as either a sibling (inline, checked-out) project or a downloaded package dependency
     const hoistPath = inlineHoist ?


### PR DESCRIPTION
Tested this change in client environment for my specific use case and everything worked fine.

Considered making the `publicPath` a parameter to the build but figured we should wait to do that until we really need to, this change should allow the apps to be hosted under any nested path/directory structure and also play nice with reverse proxies.