### PR TITLE
Allow override of dev server host

### DIFF
--- a/configureWebpack.js
+++ b/configureWebpack.js
@@ -298,7 +298,7 @@ function configureWebpack(env) {
 
         // Inline dev-time configuration for webpack-dev-server.
         devServer: prodBuild ? undefined : {
-            host: 'localhost',
+            host: new URL(baseUrl).hostname,
             port: devServerPort,
             overlay: true,
             compress: true,


### PR DESCRIPTION
If user passes a custom baseUrl to webpack dev server, use this as the dev server host. Allows us to test client apps on mobile devices.